### PR TITLE
Add DART evaluation script to save predictions and per-image overlays

### DIFF
--- a/eval_dart_predictions.py
+++ b/eval_dart_predictions.py
@@ -74,7 +74,13 @@ def run_eval(
                     }
                 )
 
-                rendered = render_overlay(imgs_np[sample_in_batch, 0], pred_uvd, gt_uvd)
+                sample_for_viz = loader.dataset.dataset[mapped_index]
+                rendered = render_overlay(
+                    imgs_np[sample_in_batch, 0],
+                    pred_uvd,
+                    gt_uvd,
+                    base_image=sample_for_viz["image"],
+                )
                 out_path = image_output_dir / f"{dataset_index:06d}_{image_name}.png"
                 rendered.save(out_path)
 
@@ -82,12 +88,16 @@ def run_eval(
     return all_rows, mean_l2
 
 
-def render_overlay(input_image, pred_uvd, gt_uvd):
+def render_overlay(input_image, pred_uvd, gt_uvd, base_image=None):
     import numpy as np
     from PIL import Image, ImageDraw
 
-    img = ((input_image + 1.0) * 127.5).clip(0, 255).astype(np.uint8)
-    canvas = Image.fromarray(img, mode="L").convert("RGB")
+    if base_image is not None:
+        canvas = base_image.convert("RGB")
+    else:
+        img = ((input_image + 1.0) * 127.5).clip(0, 255).astype(np.uint8)
+        canvas = Image.fromarray(img, mode="L").convert("RGB")
+
     draw = ImageDraw.Draw(canvas)
 
     for joint_idx in range(gt_uvd.shape[0]):

--- a/eval_dart_predictions.py
+++ b/eval_dart_predictions.py
@@ -3,17 +3,6 @@ import csv
 import os
 from pathlib import Path
 
-import cv2
-import numpy as np
-import torch
-from torch.utils.data import DataLoader
-
-from dataloader import DartHandPoseDataset
-from utils.forwardpass import get_EvalFunction
-from utils.utils import model_builder
-
-
-@torch.no_grad()
 def run_eval(
     model,
     loader,
@@ -22,95 +11,95 @@ def run_eval(
     device,
     image_output_dir,
 ):
+    import numpy as np
+    import torch
+
     model.eval()
 
     all_rows = []
     total_error = 0.0
     total_points = 0
 
-    for batch_idx, data in enumerate(loader):
-        (
-            inputs,
-            _gt2Dcrop,
-            gt2Dorignal,
-            _gt3Dorignal,
-            com,
-            _M_inv,
-            cubesize,
-            *_rest,
-        ) = data
+    with torch.no_grad():
+        for batch_idx, data in enumerate(loader):
+            (
+                inputs,
+                _gt2Dcrop,
+                gt2Dorignal,
+                _gt3Dorignal,
+                com,
+                _M_inv,
+                cubesize,
+                *_rest,
+            ) = data
 
-        inputs = inputs.to(device)
-        gt2Dorignal = gt2Dorignal.to(device)
-        com = com.to(device)
-        cubesize = cubesize.to(device)
+            inputs = inputs.to(device)
+            gt2Dorignal = gt2Dorignal.to(device)
+            com = com.to(device)
+            cubesize = cubesize.to(device)
 
-        outputs = model(inputs)
-        preds = eval_function(inputs, outputs, cubesize, com, setting)
+            outputs = model(inputs)
+            preds = eval_function(inputs, outputs, cubesize, com, setting)
 
-        preds_np = preds.detach().cpu().numpy()
-        gts_np = gt2Dorignal.detach().cpu().numpy()
-        imgs_np = inputs.detach().cpu().numpy()
+            preds_np = preds.detach().cpu().numpy()
+            gts_np = gt2Dorignal.detach().cpu().numpy()
+            imgs_np = inputs.detach().cpu().numpy()
 
-        batch_start = batch_idx * loader.batch_size
+            batch_start = batch_idx * loader.batch_size
 
-        for sample_in_batch in range(preds_np.shape[0]):
-            dataset_index = batch_start + sample_in_batch
-            mapped_index = loader.dataset.indeces[dataset_index]
-            raw_sample = loader.dataset.dataset.samples[mapped_index]
-            image_name = Path(raw_sample["image_path"]).stem
+            for sample_in_batch in range(preds_np.shape[0]):
+                dataset_index = batch_start + sample_in_batch
+                mapped_index = loader.dataset.indeces[dataset_index]
+                raw_sample = loader.dataset.dataset.samples[mapped_index]
+                image_name = Path(raw_sample["image_path"]).stem
 
-            pred_uvd = preds_np[sample_in_batch]
-            gt_uvd = gts_np[sample_in_batch]
+                pred_uvd = preds_np[sample_in_batch]
+                gt_uvd = gts_np[sample_in_batch]
 
-            sample_err = np.linalg.norm(pred_uvd - gt_uvd, axis=1)
-            total_error += float(sample_err.sum())
-            total_points += int(sample_err.shape[0])
+                sample_err = np.linalg.norm(pred_uvd - gt_uvd, axis=1)
+                total_error += float(sample_err.sum())
+                total_points += int(sample_err.shape[0])
 
-            all_rows.append(
-                {
-                    "sample_index": dataset_index,
-                    "image_path": raw_sample["image_path"],
-                    "pred_uvd": pred_uvd.copy(),
-                    "gt_uvd": gt_uvd.copy(),
-                    "mean_l2_error": float(sample_err.mean()),
-                }
-            )
+                all_rows.append(
+                    {
+                        "sample_index": dataset_index,
+                        "image_path": raw_sample["image_path"],
+                        "pred_uvd": pred_uvd.copy(),
+                        "gt_uvd": gt_uvd.copy(),
+                        "mean_l2_error": float(sample_err.mean()),
+                    }
+                )
 
-            rendered = render_overlay(imgs_np[sample_in_batch, 0], pred_uvd, gt_uvd)
-            out_path = image_output_dir / f"{dataset_index:06d}_{image_name}.png"
-            cv2.imwrite(str(out_path), rendered)
+                rendered = render_overlay(imgs_np[sample_in_batch, 0], pred_uvd, gt_uvd)
+                out_path = image_output_dir / f"{dataset_index:06d}_{image_name}.png"
+                rendered.save(out_path)
 
     mean_l2 = total_error / max(total_points, 1)
     return all_rows, mean_l2
 
 
 def render_overlay(input_image, pred_uvd, gt_uvd):
+    from PIL import Image, ImageDraw
+
     img = ((input_image + 1.0) * 127.5).clip(0, 255).astype(np.uint8)
-    canvas = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+    canvas = Image.fromarray(img, mode="L").convert("RGB")
+    draw = ImageDraw.Draw(canvas)
 
     for joint_idx in range(gt_uvd.shape[0]):
         gx, gy = int(round(gt_uvd[joint_idx, 0])), int(round(gt_uvd[joint_idx, 1]))
         px, py = int(round(pred_uvd[joint_idx, 0])), int(round(pred_uvd[joint_idx, 1]))
 
-        cv2.circle(canvas, (gx, gy), 3, (0, 255, 0), thickness=-1)
-        cv2.circle(canvas, (px, py), 3, (0, 0, 255), thickness=-1)
-        cv2.line(canvas, (gx, gy), (px, py), (255, 0, 0), thickness=1)
+        draw.ellipse((gx - 3, gy - 3, gx + 3, gy + 3), fill=(0, 255, 0))
+        draw.ellipse((px - 3, py - 3, px + 3, py + 3), fill=(255, 0, 0))
+        draw.line((gx, gy, px, py), fill=(0, 0, 255), width=1)
 
-    cv2.putText(
-        canvas,
-        "GT=green Pred=red",
-        (8, 20),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        0.5,
-        (255, 255, 255),
-        1,
-        cv2.LINE_AA,
-    )
+    draw.text((8, 8), "GT=green Pred=red", fill=(255, 255, 255))
     return canvas
 
 
 def save_predictions(rows, output_csv, output_npz):
+    import numpy as np
+
     output_csv.parent.mkdir(parents=True, exist_ok=True)
 
     with output_csv.open("w", newline="") as f:
@@ -142,8 +131,24 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Evaluate DART dataset, save predictions, and dump per-image overlays."
     )
-    parser.add_argument("--checkpoint", required=True, type=str, help="Path to .pt checkpoint")
-    parser.add_argument("--datasetpath", required=True, type=str, help="Path to DART root")
+    parser.add_argument(
+        "--checkpoint",
+        default="",
+        type=str,
+        help="Path to a specific .pt checkpoint file. Optional if --path is provided.",
+    )
+    parser.add_argument(
+        "--path",
+        default="",
+        type=str,
+        help="Checkpoint directory (e.g., experiment/checkpoints). If set, newest savedModel_E*.pt is used.",
+    )
+    parser.add_argument(
+        "--datasetpath",
+        default="",
+        type=str,
+        help="Path to DART root. Optional: falls back to checkpoint args.datasetpath or $DART_PATH.",
+    )
     parser.add_argument("--output_dir", default="dart_eval_outputs", type=str)
     parser.add_argument("--batch_size", default=32, type=int)
     parser.add_argument("--num_workers", default=4, type=int)
@@ -151,12 +156,73 @@ def parse_args():
     return parser.parse_args()
 
 
+def _extract_epoch_number(path_obj: Path) -> int:
+    name = path_obj.stem
+    if "E" in name:
+        try:
+            return int(name.split("E")[-1])
+        except ValueError:
+            return -1
+    return -1
+
+
+def _resolve_checkpoint_path(args) -> Path:
+    if args.checkpoint:
+        checkpoint = Path(args.checkpoint)
+        if checkpoint.is_file():
+            return checkpoint
+        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint}")
+
+    if args.path:
+        ckpt_dir = Path(args.path)
+        if not ckpt_dir.is_dir():
+            raise FileNotFoundError(f"Checkpoint directory not found: {ckpt_dir}")
+
+        candidates = sorted(ckpt_dir.glob("savedModel_E*.pt"), key=_extract_epoch_number)
+        if not candidates:
+            candidates = sorted(ckpt_dir.glob("*.pt"), key=_extract_epoch_number)
+        if not candidates:
+            raise FileNotFoundError(
+                f"No checkpoint files were found under: {ckpt_dir}"
+            )
+        return candidates[-1]
+
+    default_dir = Path("checkpoints")
+    if default_dir.is_dir():
+        candidates = sorted(default_dir.glob("savedModel_E*.pt"), key=_extract_epoch_number)
+        if candidates:
+            return candidates[-1]
+
+    raise ValueError(
+        "Provide either --checkpoint <file> or --path <checkpoint_dir>. "
+        "No default checkpoint could be resolved."
+    )
+
+
 def main():
     args = parse_args()
 
-    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    import torch
+    from torch.utils.data import DataLoader
+
+    from dataloader import DartHandPoseDataset
+    from utils.forwardpass import get_EvalFunction
+    from utils.utils import model_builder
+
+    checkpoint_path = _resolve_checkpoint_path(args)
+    ckpt = torch.load(checkpoint_path, map_location="cpu")
     setting = ckpt["args"]
     setting.dataset = "dart"
+
+    datasetpath = args.datasetpath
+    if datasetpath in ("", None):
+        datasetpath = getattr(setting, "datasetpath", "")
+    if datasetpath in ("", None):
+        datasetpath = os.environ.get("DART_PATH", "")
+    if datasetpath in ("", None):
+        raise ValueError(
+            "DART dataset path is missing. Set --datasetpath, or store datasetpath in checkpoint args, or export DART_PATH."
+        )
 
     device = torch.device(
         f"cuda:{args.cuda_id}" if torch.cuda.is_available() else "cpu"
@@ -164,7 +230,7 @@ def main():
 
     dataset = DartHandPoseDataset(
         train=False,
-        basepath=args.datasetpath,
+        basepath=datasetpath,
         cropSize=(setting.cropSize, setting.cropSize),
         cropSize3D=[setting.cubic_size, setting.cubic_size, setting.cubic_size],
     )
@@ -200,6 +266,8 @@ def main():
     npz_path = output_dir / "predictions.npz"
     save_predictions(rows, csv_path, npz_path)
 
+    print(f"Checkpoint: {checkpoint_path}")
+    print(f"Dataset: {datasetpath}")
     print(f"Saved {len(rows)} predictions")
     print(f"CSV: {csv_path}")
     print(f"NPZ: {npz_path}")

--- a/eval_dart_predictions.py
+++ b/eval_dart_predictions.py
@@ -1,0 +1,211 @@
+import argparse
+import csv
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from dataloader import DartHandPoseDataset
+from utils.forwardpass import get_EvalFunction
+from utils.utils import model_builder
+
+
+@torch.no_grad()
+def run_eval(
+    model,
+    loader,
+    eval_function,
+    setting,
+    device,
+    image_output_dir,
+):
+    model.eval()
+
+    all_rows = []
+    total_error = 0.0
+    total_points = 0
+
+    for batch_idx, data in enumerate(loader):
+        (
+            inputs,
+            _gt2Dcrop,
+            gt2Dorignal,
+            _gt3Dorignal,
+            com,
+            _M_inv,
+            cubesize,
+            *_rest,
+        ) = data
+
+        inputs = inputs.to(device)
+        gt2Dorignal = gt2Dorignal.to(device)
+        com = com.to(device)
+        cubesize = cubesize.to(device)
+
+        outputs = model(inputs)
+        preds = eval_function(inputs, outputs, cubesize, com, setting)
+
+        preds_np = preds.detach().cpu().numpy()
+        gts_np = gt2Dorignal.detach().cpu().numpy()
+        imgs_np = inputs.detach().cpu().numpy()
+
+        batch_start = batch_idx * loader.batch_size
+
+        for sample_in_batch in range(preds_np.shape[0]):
+            dataset_index = batch_start + sample_in_batch
+            mapped_index = loader.dataset.indeces[dataset_index]
+            raw_sample = loader.dataset.dataset.samples[mapped_index]
+            image_name = Path(raw_sample["image_path"]).stem
+
+            pred_uvd = preds_np[sample_in_batch]
+            gt_uvd = gts_np[sample_in_batch]
+
+            sample_err = np.linalg.norm(pred_uvd - gt_uvd, axis=1)
+            total_error += float(sample_err.sum())
+            total_points += int(sample_err.shape[0])
+
+            all_rows.append(
+                {
+                    "sample_index": dataset_index,
+                    "image_path": raw_sample["image_path"],
+                    "pred_uvd": pred_uvd.copy(),
+                    "gt_uvd": gt_uvd.copy(),
+                    "mean_l2_error": float(sample_err.mean()),
+                }
+            )
+
+            rendered = render_overlay(imgs_np[sample_in_batch, 0], pred_uvd, gt_uvd)
+            out_path = image_output_dir / f"{dataset_index:06d}_{image_name}.png"
+            cv2.imwrite(str(out_path), rendered)
+
+    mean_l2 = total_error / max(total_points, 1)
+    return all_rows, mean_l2
+
+
+def render_overlay(input_image, pred_uvd, gt_uvd):
+    img = ((input_image + 1.0) * 127.5).clip(0, 255).astype(np.uint8)
+    canvas = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+
+    for joint_idx in range(gt_uvd.shape[0]):
+        gx, gy = int(round(gt_uvd[joint_idx, 0])), int(round(gt_uvd[joint_idx, 1]))
+        px, py = int(round(pred_uvd[joint_idx, 0])), int(round(pred_uvd[joint_idx, 1]))
+
+        cv2.circle(canvas, (gx, gy), 3, (0, 255, 0), thickness=-1)
+        cv2.circle(canvas, (px, py), 3, (0, 0, 255), thickness=-1)
+        cv2.line(canvas, (gx, gy), (px, py), (255, 0, 0), thickness=1)
+
+    cv2.putText(
+        canvas,
+        "GT=green Pred=red",
+        (8, 20),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.5,
+        (255, 255, 255),
+        1,
+        cv2.LINE_AA,
+    )
+    return canvas
+
+
+def save_predictions(rows, output_csv, output_npz):
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_csv.open("w", newline="") as f:
+        writer = csv.writer(f)
+        header = ["sample_index", "image_path", "mean_l2_error"]
+        for j in range(21):
+            header.extend([f"pred_u_{j}", f"pred_v_{j}", f"pred_d_{j}"])
+        for j in range(21):
+            header.extend([f"gt_u_{j}", f"gt_v_{j}", f"gt_d_{j}"])
+        writer.writerow(header)
+
+        for row in rows:
+            rec = [row["sample_index"], row["image_path"], row["mean_l2_error"]]
+            rec.extend(row["pred_uvd"].reshape(-1).tolist())
+            rec.extend(row["gt_uvd"].reshape(-1).tolist())
+            writer.writerow(rec)
+
+    np.savez_compressed(
+        output_npz,
+        sample_index=np.array([r["sample_index"] for r in rows], dtype=np.int64),
+        image_path=np.array([r["image_path"] for r in rows]),
+        pred_uvd=np.stack([r["pred_uvd"] for r in rows], axis=0),
+        gt_uvd=np.stack([r["gt_uvd"] for r in rows], axis=0),
+        mean_l2_error=np.array([r["mean_l2_error"] for r in rows], dtype=np.float32),
+    )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Evaluate DART dataset, save predictions, and dump per-image overlays."
+    )
+    parser.add_argument("--checkpoint", required=True, type=str, help="Path to .pt checkpoint")
+    parser.add_argument("--datasetpath", required=True, type=str, help="Path to DART root")
+    parser.add_argument("--output_dir", default="dart_eval_outputs", type=str)
+    parser.add_argument("--batch_size", default=32, type=int)
+    parser.add_argument("--num_workers", default=4, type=int)
+    parser.add_argument("--cuda_id", default=0, type=int)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    ckpt = torch.load(args.checkpoint, map_location="cpu")
+    setting = ckpt["args"]
+    setting.dataset = "dart"
+
+    device = torch.device(
+        f"cuda:{args.cuda_id}" if torch.cuda.is_available() else "cpu"
+    )
+
+    dataset = DartHandPoseDataset(
+        train=False,
+        basepath=args.datasetpath,
+        cropSize=(setting.cropSize, setting.cropSize),
+        cropSize3D=[setting.cubic_size, setting.cubic_size, setting.cubic_size],
+    )
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
+
+    model = model_builder(
+        setting.model_name, num_joints=dataset.num_joints, args=setting
+    ).to(device)
+    model.load_state_dict(ckpt["model"])
+
+    eval_function = get_EvalFunction(setting)
+
+    output_dir = Path(args.output_dir)
+    overlays_dir = output_dir / "overlay_images"
+    overlays_dir.mkdir(parents=True, exist_ok=True)
+
+    rows, mean_l2 = run_eval(
+        model=model,
+        loader=loader,
+        eval_function=eval_function,
+        setting=setting,
+        device=device,
+        image_output_dir=overlays_dir,
+    )
+
+    csv_path = output_dir / "predictions.csv"
+    npz_path = output_dir / "predictions.npz"
+    save_predictions(rows, csv_path, npz_path)
+
+    print(f"Saved {len(rows)} predictions")
+    print(f"CSV: {csv_path}")
+    print(f"NPZ: {npz_path}")
+    print(f"Overlay images: {overlays_dir}")
+    print(f"Mean per-joint L2 error in UVD space: {mean_l2:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval_dart_predictions.py
+++ b/eval_dart_predictions.py
@@ -3,6 +3,10 @@ import csv
 import os
 from pathlib import Path
 
+DEFAULT_CHECKPOINT = "checkpoints/savedModel_E60.pt"
+DEFAULT_DATASETPATH = "data/DART"
+
+
 def run_eval(
     model,
     loader,
@@ -133,9 +137,9 @@ def parse_args():
     )
     parser.add_argument(
         "--checkpoint",
-        default="",
+        default=DEFAULT_CHECKPOINT,
         type=str,
-        help="Path to a specific .pt checkpoint file. Optional if --path is provided.",
+        help="Path to a specific .pt checkpoint file.",
     )
     parser.add_argument(
         "--path",
@@ -145,9 +149,9 @@ def parse_args():
     )
     parser.add_argument(
         "--datasetpath",
-        default="",
+        default=DEFAULT_DATASETPATH,
         type=str,
-        help="Path to DART root. Optional: falls back to checkpoint args.datasetpath or $DART_PATH.",
+        help="Path to DART root.",
     )
     parser.add_argument("--output_dir", default="dart_eval_outputs", type=str)
     parser.add_argument("--batch_size", default=32, type=int)
@@ -171,7 +175,10 @@ def _resolve_checkpoint_path(args) -> Path:
         checkpoint = Path(args.checkpoint)
         if checkpoint.is_file():
             return checkpoint
-        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint}")
+        print(
+            f"Warning: default checkpoint file was not found at '{checkpoint}'. "
+            "Falling back to directory-based checkpoint search."
+        )
 
     if args.path:
         ckpt_dir = Path(args.path)
@@ -215,13 +222,14 @@ def main():
     setting.dataset = "dart"
 
     datasetpath = args.datasetpath
-    if datasetpath in ("", None):
-        datasetpath = getattr(setting, "datasetpath", "")
-    if datasetpath in ("", None):
-        datasetpath = os.environ.get("DART_PATH", "")
-    if datasetpath in ("", None):
+    if not Path(datasetpath).exists():
+        datasetpath = getattr(setting, "datasetpath", datasetpath)
+    if not Path(datasetpath).exists():
+        datasetpath = os.environ.get("DART_PATH", datasetpath)
+    if not Path(datasetpath).exists():
         raise ValueError(
-            "DART dataset path is missing. Set --datasetpath, or store datasetpath in checkpoint args, or export DART_PATH."
+            f"DART dataset path does not exist: '{args.datasetpath}'. "
+            "Please pass a valid --datasetpath."
         )
 
     device = torch.device(

--- a/eval_dart_predictions.py
+++ b/eval_dart_predictions.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 import os
+import re
 from pathlib import Path
 
 DEFAULT_CHECKPOINT = "checkpoints/savedModel_E60.pt"
@@ -81,7 +82,10 @@ def run_eval(
                     gt_uvd,
                     base_image=sample_for_viz["image"],
                 )
-                out_path = image_output_dir / f"{dataset_index:06d}_{image_name}.png"
+                rounded_loss = int(round(float(sample_err.mean())))
+                pose_match = re.search(r"\d+", image_name)
+                pose_number = pose_match.group(0) if pose_match is not None else f"{dataset_index:06d}"
+                out_path = image_output_dir / f"{dataset_index:06d}_{pose_number}_{rounded_loss}.png"
                 rendered.save(out_path)
 
     mean_l2 = total_error / max(total_points, 1)

--- a/eval_dart_predictions.py
+++ b/eval_dart_predictions.py
@@ -83,6 +83,7 @@ def run_eval(
 
 
 def render_overlay(input_image, pred_uvd, gt_uvd):
+    import numpy as np
     from PIL import Image, ImageDraw
 
     img = ((input_image + 1.0) * 127.5).clip(0, 255).astype(np.uint8)


### PR DESCRIPTION
### Motivation
- Provide a simple, standalone tool to run inference over the full DART dataset from a saved checkpoint and export numeric predictions for downstream analysis.
- Produce both human-readable and compact programmatic outputs so results can be inspected or consumed by other tools (`.csv` and `.npz`).
- Save per-image visualizations that overlay predicted joints and ground truth to speed qualitative error analysis.

### Description
- Add `eval_dart_predictions.py` which loads a checkpoint, instantiates `DartHandPoseDataset`, runs the model, and computes per-sample UVD predictions via `get_EvalFunction`.
- Write per-sample records to `predictions.csv` (flat columns) and a compressed `predictions.npz` containing arrays for `sample_index`, `image_path`, `pred_uvd`, `gt_uvd`, and `mean_l2_error`.
- Render and save one overlay image per sample into `<output_dir>/overlay_images/` with ground-truth joints in green, predictions in red, and GT→Pred connector lines in blue.
- Expose a small CLI (`--checkpoint`, `--datasetpath`, `--output_dir`, `--batch_size`, `--num_workers`, `--cuda_id`) to control the run.

### Testing
- Compiled the new script with `python -m py_compile eval_dart_predictions.py` which completed without errors.
- No additional automated tests were added in this change; run the script on a DART checkpoint to validate end-to-end behavior and outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd6696886c8329b58d4e10606c8efd)